### PR TITLE
Make NSO layout optional, tweak Classic Controller

### DIFF
--- a/libultraship/libultraship/WiiUController.cpp
+++ b/libultraship/libultraship/WiiUController.cpp
@@ -16,7 +16,7 @@ namespace Ship {
 		KPADShutdown();
 	}
 
-	static bool nsoPad;
+	static bool nsoPad = false;
 
 	void WiiUController::ReadFromSource() {
 		dwPressedButtons = 0;
@@ -81,9 +81,9 @@ namespace Ship {
 				case WPAD_EXT_PRO_CONTROLLER:
 
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_STICK_R)
-						nsoPad = 0;
+						nsoPad = false;
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_UP && kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP)
-						nsoPad = 1;
+						nsoPad = true;
 
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_A)
 						dwPressedButtons |= BTN_A;

--- a/libultraship/libultraship/WiiUController.cpp
+++ b/libultraship/libultraship/WiiUController.cpp
@@ -82,7 +82,7 @@ namespace Ship {
 
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_STICK_R)
 						nsoPad = 0;
-					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP & WPAD_PRO_STICK_R_EMULATION_DOWN & WPAD_PRO_STICK_R_EMULATION_LEFT & WPAD_PRO_STICK_R_EMULATION_RIGHT)
+					if (kStatus.pro.hold & WPAD_PRO_BUTTON_UP && kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP)
 						nsoPad = 1;
 
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_A)

--- a/libultraship/libultraship/WiiUController.cpp
+++ b/libultraship/libultraship/WiiUController.cpp
@@ -16,6 +16,8 @@ namespace Ship {
 		KPADShutdown();
 	}
 
+	static bool nsoPad;
+
 	void WiiUController::ReadFromSource() {
 		dwPressedButtons = 0;
 		wStickX = 0;
@@ -77,15 +79,21 @@ namespace Ship {
 
 			switch (kType) {
 				case WPAD_EXT_PRO_CONTROLLER:
+
+					if (kStatus.pro.hold & WPAD_PRO_BUTTON_STICK_R)
+						nsoPad = 0;
+					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP & WPAD_PRO_STICK_R_EMULATION_DOWN & WPAD_PRO_STICK_R_EMULATION_LEFT & WPAD_PRO_STICK_R_EMULATION_RIGHT)
+						nsoPad = 1;
+
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_A)
 						dwPressedButtons |= BTN_A;
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_B)
 						dwPressedButtons |= BTN_B;
 					if (kStatus.pro.hold & WPAD_PRO_TRIGGER_ZL)
 						dwPressedButtons |= BTN_Z;
-					if (kStatus.pro.hold & WPAD_PRO_TRIGGER_R)
+					if (kStatus.pro.hold & (nsoPad ? WPAD_PRO_TRIGGER_R : WPAD_PRO_TRIGGER_ZR))
 						dwPressedButtons |= BTN_R;
-					if (kStatus.pro.hold & WPAD_PRO_TRIGGER_L)
+					if (kStatus.pro.hold & (nsoPad ? WPAD_PRO_TRIGGER_L : WPAD_PRO_BUTTON_MINUS))
 						dwPressedButtons |= BTN_L;
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_PLUS)
 						dwPressedButtons |= BTN_START;
@@ -98,13 +106,13 @@ namespace Ship {
 					if (kStatus.pro.hold & WPAD_PRO_BUTTON_LEFT)
 						dwPressedButtons |= BTN_DLEFT;
 
-					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_RIGHT)
+					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_RIGHT || kStatus.pro.hold & WPAD_PRO_BUTTON_X)
 						dwPressedButtons |= BTN_CRIGHT;
-					else if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_LEFT)
+					else if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_LEFT || kStatus.pro.hold & WPAD_PRO_BUTTON_Y)
 						dwPressedButtons |= BTN_CLEFT;
-					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP)
+					if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_UP || kStatus.pro.hold & (nsoPad ? 0 : WPAD_PRO_TRIGGER_L))
 						dwPressedButtons |= BTN_CUP;
-					else if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_DOWN)
+					else if (kStatus.pro.hold & WPAD_PRO_STICK_R_EMULATION_DOWN || kStatus.pro.hold & (nsoPad ? 0 : WPAD_PRO_TRIGGER_R))
 						dwPressedButtons |= BTN_CDOWN;
 
 					wStickX += kStatus.pro.leftStick.x * 84;
@@ -116,11 +124,11 @@ namespace Ship {
 						dwPressedButtons |= BTN_A;
 					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_B)
 						dwPressedButtons |= BTN_B;
-					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_ZL)
+					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_L)
 						dwPressedButtons |= BTN_Z;
 					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_R)
 						dwPressedButtons |= BTN_R;
-					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_L)
+					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_MINUS)
 						dwPressedButtons |= BTN_L;
 					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_PLUS)
 						dwPressedButtons |= BTN_START;
@@ -133,13 +141,13 @@ namespace Ship {
 					if (kStatus.classic.hold & WPAD_CLASSIC_BUTTON_LEFT)
 						dwPressedButtons |= BTN_DLEFT;
 
-					if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_RIGHT)
+					if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_RIGHT || kStatus.classic.hold & WPAD_CLASSIC_BUTTON_X)
 						dwPressedButtons |= BTN_CRIGHT;
-					else if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_LEFT)
+					else if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_LEFT || kStatus.classic.hold & WPAD_CLASSIC_BUTTON_Y)
 						dwPressedButtons |= BTN_CLEFT;
-					if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_UP)
+					if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_UP || kStatus.classic.hold & WPAD_CLASSIC_BUTTON_ZL)
 						dwPressedButtons |= BTN_CUP;
-					else if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_DOWN)
+					else if (kStatus.classic.hold & WPAD_CLASSIC_STICK_R_EMULATION_DOWN || kStatus.classic.hold & WPAD_CLASSIC_BUTTON_ZR)
 						dwPressedButtons |= BTN_CDOWN;
 
 					wStickX += kStatus.classic.leftStick.x * 84;


### PR DESCRIPTION
How about this? The main change here is to Wii U Pro Controllers. The default setup matches the layout I suggested for VPAD. Users can toggle to NSO N64 controller mode if they're using one of those.

**Pro Controller changes:**
- press D-Pad Up and C-Up simultaneously to enable NSO mode
puts the N64 Z/R buttons on WUPC ZL/R, like the NSO pad
- click the right stick to disable NSO mode
puts the N64 Z/R buttons back on WUPC ZL/ZR, like the Wii U GamePad

Note that I don't have an NSO N64 controller, so this is untested on real hardware. Somebody should confirm whether it actually works if this gets merged.

I think it makes the most sense to assume by default that users *aren't* using an NSO N64 controller, since Wii U Pro Controllers and other Bloopaired controllers which mimic them are far more common than NSO pads.

**Classic Controller changes:**

For legacy Wii Classic Controllers, I again matched the VPAD layout (itself based on Ocarina of Time for GameCube and Wii Virtual Console, and Wind Waker HD and Twilight Princess HD for Wii U). The only exception here is that L/ZL and R/ZR are swapped, as the L/R buttons are the primary shoulder buttons on Wii Classic Controllers, unlike the Wii U GamePad/Pro Controller where ZL/ZR are preferred.

Binary attached in case it helps with testing.
[soh.zip](https://github.com/V10lator/Shipwright/files/8461700/soh.zip)
